### PR TITLE
fixing the Restart method to have 'restart' for the URL suffix

### DIFF
--- a/arm-remoteapp/2014-09-01/swagger/remoteapp.json
+++ b/arm-remoteapp/2014-09-01/swagger/remoteapp.json
@@ -1489,6 +1489,31 @@
                     }
                 }
             },
+            "parameters": [
+                {
+                    "name": "collectionName",
+                    "in": "path",
+                    "required": true,
+                    "type": "string",
+                    "description": "The collection name."
+                },
+                {
+                    "name": "resourceGroupName",
+                    "in": "path",
+                    "required": true,
+                    "type": "string",
+                    "description": "The name of the resource group"
+                },
+                {
+                    "name": "virtualMachine",
+                    "in": "path",
+                    "required": true,
+                    "type": "string",
+                    "description": "The virtual machine name"
+                }
+            ]
+		},
+		"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{armNamespace}/collections/{collectionName}/vms/{virtualMachine}/restart": {
             "post": {
                 "tags": [
                     "Collection"
@@ -1549,8 +1574,6 @@
                 }
             ]
         }
-
-
     },
     "definitions": {
         "AccountDetails": {


### PR DESCRIPTION
Please pull this change which changes the swagger spec for ListVM and RestartVM. These both have distinct URLs which I missed.
